### PR TITLE
Fix match_badip regular expression.

### DIFF
--- a/sshscan.py
+++ b/sshscan.py
@@ -191,7 +191,7 @@ for line in rand_lines:
                 count_ips += 1
 
                 # Don't scan network and broadcast addresses
-                match_badip = re.search('\.0|255$', str(ip))
+                match_badip = re.search('\.(0|255)$', str(ip))
                 if match_badip:
                     continue
                 # If status is defined, we know the connection failed


### PR DESCRIPTION
match_badip was preventing scanning any IP with 0 anywhere in the address. In particular 10.0.1.1 is a valid address rejected by match_badip.
